### PR TITLE
fix searching p8-platform headers

### DIFF
--- a/lib/UnrarXLib/rdwrfn.hpp
+++ b/lib/UnrarXLib/rdwrfn.hpp
@@ -4,7 +4,7 @@
 class CmdAdd;
 class Unpack;
 
-#include <threads/mutex.h>
+#include "p8-platform/threads/mutex.h"
 
 class ComprDataIO
 {

--- a/src/RarExtractThread.h
+++ b/src/RarExtractThread.h
@@ -21,7 +21,7 @@
 #ifndef RAR_EXTRACT_THREAD_H_
 #define RAR_EXTRACT_THREAD_H_
 
-#include <threads/threads.h>
+#include "p8-platform/threads/threads.h"
 
 class Archive;
 class CmdExtract;

--- a/src/RarFile.cpp
+++ b/src/RarFile.cpp
@@ -19,7 +19,7 @@
  */
 
 #include "libXBMC_addon.h"
-#include "threads/mutex.h"
+#include "p8-platform/threads/mutex.h"
 #include <map>
 #include <sstream>
 #include <fcntl.h>

--- a/src/RarManager.h
+++ b/src/RarManager.h
@@ -26,7 +26,7 @@
 
 #include "UnrarX.hpp"
 
-#include <threads/threads.h>
+#include "p8-platform/threads/threads.h"
 #include <kodi_vfs_types.h>
 
 #define EXFILE_OVERWRITE 1


### PR DESCRIPTION
as title says. all other addons are including p8-platform headers the same way.

after this PR, I think it is time to add vfs.rar to https://github.com/xbmc/repo-binary-addons