### PR TITLE
[fix] revert -fPIC from last commit

### DIFF
--- a/lib/UnrarXLib/CMakeLists.txt
+++ b/lib/UnrarXLib/CMakeLists.txt
@@ -41,9 +41,11 @@ set(SOURCES archive.cpp
             unpack.cpp
             volume.cpp)
 
+add_options(ALL_LANGUAGES ALL_BUILDS "-fPIC")
+
 add_library(unrarxlib STATIC ${SOURCES})
 if(NOT CORE_SYSTEM_NAME STREQUAL windows)
-  target_compile_definitions(unrarxlib PRIVATE -DSILENT -fPIC)
+  target_compile_definitions(unrarxlib PRIVATE -DSILENT)
 else()
   target_compile_definitions(unrarxlib PRIVATE -D_XBMC -Dstrcasecmp=_stricmp)
 endif()


### PR DESCRIPTION
at least ios failed to build. it seems we tested an earlier version of my PR where -fPIC was not moved to target_compile_definitions. sorry for that