### PR TITLE
[windows] undef (Create|Remove)Directory

### DIFF
--- a/src/RarFile.cpp
+++ b/src/RarFile.cpp
@@ -20,6 +20,12 @@
 
 #include "libXBMC_addon.h"
 #include "p8-platform/threads/mutex.h"
+#if defined(CreateDirectory)
+#undef CreateDirectory
+#endif
+#if defined(RemoveDirectory)
+#undef RemoveDirectory
+#endif
 #include <algorithm>
 #include <cctype>
 #include <map>


### PR DESCRIPTION
If `windows.h` gets included (Create|Remove)Directory are defined to some windows specific macro and will clash with our functions.
So we need to undefine  them.
This is needed for xbmc/xbmc#11977