### PR TITLE
Fix "VMSF_DELTA filter in unrar allows arbitrary memory write"

### DIFF
--- a/lib/UnrarXLib/rarvm.cpp
+++ b/lib/UnrarXLib/rarvm.cpp
@@ -873,14 +873,16 @@ void RarVM::ExecuteStandardFilter(VM_StandardFilters FilterType)
       break;
     case VMSF_DELTA:
       {
-        int DataSize=R[4],Channels=R[0],SrcPos=0,Border=DataSize*2;
-        SET_VALUE(false,&Mem[VM_GLOBALMEMADDR+0x20],DataSize);
-        if (DataSize>=VM_GLOBALMEMADDR/2)
+        uint DataSize=R[4],Channels=R[0],SrcPos=0,Border=DataSize*2;
+        if (DataSize>VM_MEMSIZE/2 || Channels>MAX3_UNPACK_CHANNELS || Channels==0)
           break;
-        for (int CurChannel=0;CurChannel<Channels;CurChannel++)
+
+        // Bytes from same channels are grouped to continual data blocks,
+        // so we need to place them back to their interleaving positions.
+        for (uint CurChannel=0;CurChannel<Channels;CurChannel++)
         {
           byte PrevByte=0;
-          for (int DestPos=DataSize+CurChannel;DestPos<Border;DestPos+=Channels)
+          for (uint DestPos=DataSize+CurChannel;DestPos<Border;DestPos+=Channels)
             Mem[DestPos]=(PrevByte-=Mem[SrcPos++]);
         }
       }

--- a/lib/UnrarXLib/unpack.hpp
+++ b/lib/UnrarXLib/unpack.hpp
@@ -1,6 +1,12 @@
 #ifndef _RAR_UNPACK_
 #define _RAR_UNPACK_
 
+// Limit maximum number of channels in RAR3 delta filter to some reasonable
+// value to prevent too slow processing of corrupt archives with invalid
+// channels number. Must be equal or larger than v3_MAX_FILTER_CHANNELS.
+// No need to provide it for RAR5, which uses only 5 bits to store channels.
+#define MAX3_UNPACK_CHANNELS      1024
+
 enum BLOCK_TYPES {BLOCK_LZ,BLOCK_PPM};
 
 struct Decode


### PR DESCRIPTION
Addresses the "Sophos Anti-Virus RAR VMSF_DELTA Filter Signedness Error" vulnerability

See https://bugs.chromium.org/p/project-zero/issues/detail?id=1286

Fixes #9

*Please* check this code and ensure it is correct and addresses the issue. I merely went off a diff between unrar versions - this is not my area of expertise so I may have missed something.