### PR TITLE
[lib] fix seg fault in File::FileLength

### DIFF
--- a/lib/UnrarXLib/file.cpp
+++ b/lib/UnrarXLib/file.cpp
@@ -688,7 +688,7 @@ void File::SetCloseFileStat(RarTime *ftm,RarTime *fta,uint FileAttr)
 
 Int64 File::FileLength()
 {
-  return (m_File->GetLength());
+  return m_File ? m_File->GetLength() : 0;
 }
 
 


### PR DESCRIPTION
Got some seg faults with the following crashlog. This happens randomly if entered my movies library.

I've added a null check to `m_File` which solved the issue. Not sure if that is related to the latest changes introduced by @AlwinEsch. 

```
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
Core was generated by `/usr/lib/x86_64-linux-gnu/kodi/kodi.bin'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00007f067c2205d4 in File::FileLength() () from /usr/lib/x86_64-linux-gnu/kodi/addons/vfs.rar/vfs.rar.so.2.0.0
[Current thread is 1 (Thread 0x7f05bfb4c700 (LWP 19571))]

Thread 1 (Thread 0x7f05bfb4c700 (LWP 19571)):
#0  0x00007f067c2205d4 in File::FileLength() () from /usr/lib/x86_64-linux-gnu/kodi/addons/vfs.rar/vfs.rar.so.2.0.0
#1  0x00007f067c220622 in File::RawSeek(long long, int) () from /usr/lib/x86_64-linux-gnu/kodi/addons/vfs.rar/vfs.rar.so.2.0.0
#2  0x00007f067c220679 in File::Seek(long long, int) () from /usr/lib/x86_64-linux-gnu/kodi/addons/vfs.rar/vfs.rar.so.2.0.0
#3  0x00007f067c23672c in MergeArchive(Archive&, ComprDataIO*, bool, char) () from /usr/lib/x86_64-linux-gnu/kodi/addons/vfs.rar/vfs.rar.so.2.0.0
#4  0x00007f067c2257f7 in ComprDataIO::UnpRead(unsigned char*, unsigned int) () from /usr/lib/x86_64-linux-gnu/kodi/addons/vfs.rar/vfs.rar.so.2.0.0
#5  0x00007f067c21b96c in CmdExtract::UnstoreFile(ComprDataIO&, long long) () from /usr/lib/x86_64-linux-gnu/kodi/addons/vfs.rar/vfs.rar.so.2.0.0
#6  0x00007f067c21e26b in CmdExtract::ExtractCurrentFile(CommandData*, Archive&, int, bool&) () from /usr/lib/x86_64-linux-gnu/kodi/addons/vfs.rar/vfs.rar.so.2.0.0
#7  0x00007f067c20bd0f in CRarFileExtractThread::Process() () from /usr/lib/x86_64-linux-gnu/kodi/addons/vfs.rar/vfs.rar.so.2.0.0
#8  0x00007f067c20cac3 in P8PLATFORM::CThread::ThreadHandler(void*) () from /usr/lib/x86_64-linux-gnu/kodi/addons/vfs.rar/vfs.rar.so.2.0.0
#9  0x00007f069a6aa6ba in start_thread (arg=0x7f05bfb4c700) at pthread_create.c:333
#10 0x00007f06935f33dd in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:109
```