### PR TITLE
[fix] CVFSCallbacks must be constructed after #xbmc/12675

### DIFF
--- a/src/RarFile.cpp
+++ b/src/RarFile.cpp
@@ -697,7 +697,8 @@ void CRARFile::DisconnectAll()
 bool CRARFile::DirectoryExists(const VFSURL& url)
 {
   std::vector<kodi::vfs::CDirEntry> items;
-  return GetDirectory(url, items, nullptr);
+  CVFSCallbacks callbacks(nullptr);
+  return GetDirectory(url, items, callbacks);
 }
 
 bool CRARFile::GetDirectory(const VFSURL& url, std::vector<kodi::vfs::CDirEntry>& items, CVFSCallbacks callbacks)

--- a/vfs.rar/addon.xml.in
+++ b/vfs.rar/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="vfs.rar"
-  version="2.0.0"
+  version="2.0.1"
   name="RAR archive support"
   provider-name="spiff">
   <requires>@ADDON_DEPENDS@</requires>


### PR DESCRIPTION
Not sure if that makes sense on that side, but without it can't compile after #xbmc/12675