### PR TITLE
fix Prealloc call failing and properly check for first volume of archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ vfs.rar/addon.xml
 
 # KDev
 *.kdev4
+/.vs

--- a/lib/UnrarXLib/archive.cpp
+++ b/lib/UnrarXLib/archive.cpp
@@ -188,6 +188,7 @@ bool Archive::IsArchive(bool EnableBroken)
 #ifdef RARDLL
   SilentOpen=true;
 #endif
+  if (Encrypted) return (true);
   if (!SilentOpen || !Encrypted)
   {
     SaveFilePos SavePos(*this);

--- a/lib/UnrarXLib/extract.cpp
+++ b/lib/UnrarXLib/extract.cpp
@@ -736,10 +736,13 @@ bool CmdExtract::ExtractCurrentFile(CommandData *Cmd,Archive &Arc,int HeaderSize
       DataIO.SetSkipUnpCRC(SkipSolid);
 
 #ifndef _WIN_CE
-      if (!TestMode && !Arc.BrokenFileHeader &&
-         (Arc.NewLhd.FullPackSize<<11)>Arc.NewLhd.FullUnpSize &&
-      (Arc.NewLhd.FullUnpSize<100000000 || Arc.FileLength()>Arc.NewLhd.FullPackSize))
-    CurFile.Prealloc(Arc.NewLhd.FullUnpSize);
+      if (GetDataIO().UnpackToMemorySize == -1)
+      {
+        if (!TestMode && !Arc.BrokenFileHeader &&
+          (Arc.NewLhd.FullPackSize << 11)>Arc.NewLhd.FullUnpSize &&
+          (Arc.NewLhd.FullUnpSize<100000000 || Arc.FileLength()>Arc.NewLhd.FullPackSize))
+          CurFile.Prealloc(Arc.NewLhd.FullUnpSize);
+      }
 #endif
     CurFile.SetAllowDelete(!Cmd->KeepBroken);
 

--- a/lib/UnrarXLib/extract.cpp
+++ b/lib/UnrarXLib/extract.cpp
@@ -183,6 +183,7 @@ EXTRACT_ARC_CODE CmdExtract::ExtractArchive(CommandData *Cmd)
 
 bool CmdExtract::ExtractCurrentFile(CommandData *Cmd,Archive &Arc,int HeaderSize,bool &Repeat)
 {
+  if (Arc.NotFirstVolume) return false;
   if (!Unp)
   {
     Unp=new Unpack(&DataIO);

--- a/src/RarManager.cpp
+++ b/src/RarManager.cpp
@@ -241,8 +241,18 @@ bool CRarManager::GetFilesInRar(std::vector<kodi::vfs::CDirEntry>& vecpItems, co
     std::string strName;
 
     /* convert to utf8 */
-    if( pIterator->item.NameW && wcslen(pIterator->item.NameW) > 0)
-      ;//g_charsetConverter.wToUTF8(pIterator->item.NameW, strName); // TODO
+    if (pIterator->item.NameW && wcslen(pIterator->item.NameW) > 0)
+    {
+      //use Name instead if we have it
+      if (pIterator->item.Name && strlen(pIterator->item.Name) > 0)
+      {
+        kodi::UnknownToUTF8(pIterator->item.Name, strName);
+      }
+      else
+      {
+        ;//g_charsetConverter.wToUTF8(pIterator->item.NameW, strName); // TODO
+      }
+    }
     else
     {
       kodi::UnknownToUTF8(pIterator->item.Name, strName);


### PR DESCRIPTION
m_File within CurFile is created around line 664 only if UnpackToMemorySize == -1
Prealloc is called assuming the above has been created so I have protected the call the same way

This compiles and works happily on Windows x64

I believe this fixes PR#13

Addition: Changed the check for first volume of archive to not depend on parts of filenames but to read the properties of the archive. Also do not accept encrypted archives