### PR TITLE
Fix support of multiple files within multi-rar archive

### DIFF
--- a/lib/UnrarXLib/extract.cpp
+++ b/lib/UnrarXLib/extract.cpp
@@ -183,7 +183,6 @@ EXTRACT_ARC_CODE CmdExtract::ExtractArchive(CommandData *Cmd)
 
 bool CmdExtract::ExtractCurrentFile(CommandData *Cmd,Archive &Arc,int HeaderSize,bool &Repeat)
 {
-  if (Arc.NotFirstVolume) return false;
   if (!Unp)
   {
     Unp=new Unpack(&DataIO);


### PR DESCRIPTION
Add support for a multi rar set which has multiple files in it (possibly within folders as well). The video files can start in a volume that is not the first volume

The code is similar to that of listing the files: urarlib_list (RAR files only appear to contain info about files that are within that volume). Thus the code asks for the next volume and keeps looking until it finds the file. In this case it opens the file rather than adding its name to a list of files.

Regarding the modification in GetFilesInRar - it doesn't appear necessary in current Kodi 18 to specifically create the folder structure. Given a filename of "folder\file.mkv", Kodi will itself create the directory structure. This modification only deals with the files itself and adds the full path to the output vector that gets returned to Kodi.

I might try optimize it sometime but it does work
