### PR TITLE
[fix][android] include endian.h

### DIFF
--- a/lib/UnrarXLib/os.hpp
+++ b/lib/UnrarXLib/os.hpp
@@ -151,6 +151,9 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#if defined(__ANDROID__)
+#include <endian.h>
+#endif
 #include <sys/file.h>
 #if defined(__QNXNTO__)
   #include <sys/param.h>


### PR DESCRIPTION
endian.h isn't included by sys/stat.h in android NDK 16 anymore

compile tested for osx, ios and android